### PR TITLE
Bump version due to pypi.org error

### DIFF
--- a/pyark/version.py
+++ b/pyark/version.py
@@ -1,2 +1,2 @@
 """Version module to be read from various places"""
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
I deleted version 1.1.0 on pypi because I wanted to reupload the sources to integrate the latest README file. Actually pypi prevents you from uploading the same version again once deleted. :(

Meaning we have to bump the version again to include the latest README.